### PR TITLE
Enable operator modifier commands to be saved and retrieved from tx.Transactions

### DIFF
--- a/lib/transactions_common.js
+++ b/lib/transactions_common.js
@@ -221,7 +221,6 @@ Transact.prototype.commit = function(txid,callback,newId) {
   else {
     this.log('Beginning commit with transaction_id: ' + this._transaction_id);
     var newIdValues = [];
-    // console.log("Items in the stack: ",this._executionStack);
     try {
       // It would be good to update the database with the info about what we're going to try before trying it, so if there's a fatal error we can take a look at what might have caused it
       // However, that data's not available until after the items on the exectution stack have been executed
@@ -549,7 +548,7 @@ Transact.prototype.update = function(collection,doc,updates,opt,callback) {
             // TODO
             break;
         }
-        var inverse = {command:inverseCommand,data:formerValues}; // console.log("inverse op: ",opt.inverse);
+        var inverse = {command:inverseCommand,data:formerValues}; // console.log("inverse op: ",JSON.stringify(inverse));
       }
       else {
         var inverse = opt.inverse;    
@@ -685,7 +684,7 @@ Transact.prototype._checkTransactionFields = function (items,txid) {
   var self = this,recombinedUpdateFields = {},recombinedInverseFields = {};
   var action,collection,doc,details,inverseDetails,fail = false;
   _.each(items,function(val,key) {
-    if (!fail) {
+     if (!fail) {
       _.each(val, function(value) {
         if (!fail) {
           collection = value.collection;
@@ -849,7 +848,7 @@ Transact.prototype._setContext = function(context) {
 Transact.prototype._unpackageForUpdate = function(data) {
   var objForUpdate = {};
   _.each(data, function(val) {
-    objForUpdate[val.key] = val.value;
+    objForUpdate[val.key] = restoreKeysIf1stCharacterWas$(val.value);
   });
   return objForUpdate;
 }
@@ -859,11 +858,47 @@ Transact.prototype._unpackageForUpdate = function(data) {
 Transact.prototype._packageForStorage = function(update) {
   var arrForStorage = [];
   _.each(update.data, function(value,key) {
-    arrForStorage.push({key:key,value:value});
+    arrForStorage.push({key:key,value:replaceKeysIf1stCharacterIs$(value)});
   });
   return {command:update.command,data:arrForStorage};
   
 }
+
+/**
+ * Recursive function to ensure '$' is not 1st character for any object key in
+ * a document persisted to a Mongo collection.
+ *
+ * Any keys that start with $ are placed with keys that start with _$
+ */
+function replaceKeysIf1stCharacterIs$ (data) {
+  _.each(_.keys(data), function (key) {
+    if (_.isObject(data[key])) {
+      data[key] = replaceKeysIf1stCharacterIs$(data[key]);
+    }
+    if (key.indexOf('$') === 0) {
+      data['\uFF04' + key.substring(1)] = data[key];
+      delete data[key];
+    }
+  })
+  return data;
+};
+
+/**
+ * Recursive function to restore $ - starting fields
+ */
+function restoreKeysIf1stCharacterWas$ (data) {
+  _.each(_.keys(data), function (key) {
+    if (_.isObject(data[key])) {
+      data[key] = restoreKeysIf1stCharacterWas$(data[key]);
+    }
+    if (key.indexOf('\uFF04') === 0) {
+      data['$' + key.substring(1)] = data[key];
+      delete data[key];
+    }
+  })
+  return data;
+};
+
 
 // Given a dot delimited string as a key, and an object, find the value
 


### PR DESCRIPTION
This partially addresses #14 by enabling update commands like:

```javascript
      fooCollection.update(
        {_id: insertedFooDoc._id},
        {
          $addToSet: {
            foo: {$each: newBars}
          }
        },
        {tx: true});
```
to be successfully saved into the tx.Transactions collection.

NB: Need further changes to support correct inverse commands for `$addToSet` before this issue can be completed.