### PR TITLE
tx.inverseOperations

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,30 +132,27 @@ Now this post can be restored, along with all its comments, with one click of th
 		  ]
 		}
 
-If you want to override the default inverse operation for a specific update operation, you can supply your own function in the `tx.inverseOperations` hash.  For example, if you wanted to restore the entire current state of an array field after a `$push` or `$addToSet` operation, you could implement it like this:
+	If you want to override the default inverse operation for a specific update operation, you can supply your own function in the `tx.inverseOperations` hash.  For example, if you wanted to restore the entire current state of an array field after a `$push` or `$addToSet` operation, you could implement it like this:
 
-```javascript
-tx.inverseOperations.$addToSet = function (collection, existingDoc, updateMap, opt) {
-  // Function to use $set or $unset to restore original state of updated fields
-  var self = this, inverseCommand = '$set', formerValues = {};
-  // Brute force approach to ensure previous array is restored on undo
-  // even if $addToSet uses sub-modifiers like $each / $slice
-  // console.log('existingDoc:'+JSON.stringify(existingDoc));
-  _.each(_.keys(updateMap), function (keyName) {
-    var formerVal = self._drillDown(existingDoc,keyName);
-     if (typeof formerVal !== 'undefined') {
-      formerValues[keyName] = formerVal;
-     } else {
-      // Reset to empty array. Really should be an $unset but cannot mix inverse actions
-      formerValues[keyName] = [];
-     }
-  })
-  return {command:inverseCommand,data:formerValues};
-};
+		tx.inverseOperations.$addToSet = function (collection, existingDoc, updateMap, opt) {
+		  // Function to use $set or $unset to restore original state of updated fields
+		  var self = this, inverseCommand = '$set', formerValues = {};
+		  // Brute force approach to ensure previous array is restored on undo
+		  // even if $addToSet uses sub-modifiers like $each / $slice
+		  // console.log('existingDoc:'+JSON.stringify(existingDoc));
+		  _.each(_.keys(updateMap), function (keyName) {
+		    var formerVal = self._drillDown(existingDoc,keyName);
+		     if (typeof formerVal !== 'undefined') {
+		      formerValues[keyName] = formerVal;
+		     } else {
+		      // Reset to empty array. Really should be an $unset but cannot mix inverse actions
+		      formerValues[keyName] = [];
+		     }
+		  })
+		  return {command:inverseCommand,data:formerValues};
+		};
 
-```
-
-Note that supplying a `inverse` options property in an individual update always takes precedence over the functions in `tx.inverseOperations`. 
+	Note that supplying a `inverse` options property in an individual update always takes precedence over the functions in `tx.inverseOperations`. 
 
 9. The transaction queue is either processed entirely on the client or entirely on the server.  You can't mix client-side calls and server-side calls (i.e. Meteor methods) in a single transaction. If the transaction is processed on the client, then a successfully processed queue will be sent to the server via DDP as a bunch of regular "insert", "udpate" and "remove" methods, so each action will have to get through your allow and deny rules. This means that your `tx.permissionCheck` function will need to be aligned fairly closely to your `allow` and `deny` rules in order to get the expected results. If the transaction is processed entirely on the server (i.e. in a Meteor method call), the `tx.permissionCheck` function is all that stands between the method code and your database, unless you do some other permission checking within the method before executing a transaction.
 

--- a/lib/transactions_common.js
+++ b/lib/transactions_common.js
@@ -104,6 +104,40 @@ var Transact = function() {
   
   this.softDelete = false;
   
+  // Functions to work out the inverse operation that will reverse a single collection update command.
+  // This default implementation attempts to reverse individual array $set and $addToSet operations with
+  // corresponding $pull operations, but this may not work in some cases, eg:
+  // 1.  if a $set operation does nothing because the value is already in the array, the inverse $pull will remove that value freom the array, even though
+  //     it was there before the $set action
+  // 2.  if a $addToSet operation had a $each qualifier (to add multiple values), the default inverse $pull operation will fail because $each is not suported for $pull operations
+  // 
+  // You may wish to provide your own implementations that override some of these functions to address these issues if they affect your own application.
+  // For example, store the entire state of the array being mutated by a $set / $addToSet or $pull operation, and then restore it using a inverse $set operation.
+  // The tx.inverse function is called with the tx object as the `this` data context.
+  // 
+  
+  this.inverseOperations = {
+    '$set': this._inverseUsingSet,
+    '$addToSet': function (collection, existingDoc, updateMap, opt) {
+      // Inverse of $addToSet is $pull.
+      // This will not work if $addToSet uses modifiers like $each.
+      // In that case, you need to restore state of original array using $set
+      return {command: '$pull', data: updateMap};
+    },
+    '$unset': this._inverseUsingSet,
+    '$pull': function (collection, existingDoc, updateMap, opt) {
+      // Inverse of $pull is $addToSet.
+      return {command: '$addToSet', data: updateMap};
+    },
+    '$inc': this._inverseUsingSet,
+    '$push': function (collection, existingDoc, updateMap, opt) {
+      // Inverse of $push is $pull.
+      // This will not work if $push uses modifiers like $each, or if pushed value has duplicates in same array (because $pull will remove all instances of that value).
+      // In that case, you need to restore state of original array using $set
+      return {command: '$pull', data: updateMap};
+    },
+  };
+
   // ***************************
   // DONT OVERWRITE ANY OF THESE
   // ***************************
@@ -118,14 +152,7 @@ var Transact = function() {
   this._autoCancel = null;
   this._lastTransactionData = null;
   this._context = {};
-  this._inverseOps = {
-    '$set' : '$set',
-    '$addToSet' : '$pull',
-    '$unset' : '$set',
-    '$pull' : '$addToSet',
-    '$inc' : '$set',
-    '$push' : '$set' // this is a buggy hack that will only work in certain simple scenarios -- using "$push" is NOT RECOMMENDED
-  }
+
 }
 
 // **********
@@ -144,7 +171,7 @@ Transact.prototype.start = function(description) {
   if (!this._transaction_id) {
     if (typeof description === 'undefined') {
       description = 'last action';  
-    }
+    } 
     this._transaction_id = Transactions.insert({user_id:Meteor.userId(),timestamp:(new Date).getTime(),description:description});
     this.log('Started "' + description + '" with transaction_id: ' + this._transaction_id + ((this._autoTransaction) ? ' (auto started)' : ''));
     return this._transaction_id;
@@ -501,57 +528,23 @@ Transact.prototype.update = function(collection,doc,updates,opt,callback) {
     this._openAutoTransaction('update ' + collection._name.slice(0, - 1));
     var actionFields = _.pairs(updates); // console.log(actionField);
     var actionFieldsCount = actionFields.length;
-	var temp = {};
+	  var temp = {};
     for (var i = 0; i < actionFieldsCount; i++) {
       var command = actionFields[i][0]; // console.log("command:",command);
-      var updateMap = actionFields[i][1]; // console.log("updateMap:",updateMap);
+      var updateMap = actionFields[i][1]; // console.log("updateMap:",JSON.stringify(updateMap));
+      var inverse;
       if (typeof opt === 'undefined' || typeof opt.inverse === 'undefined') {
-        // This "opt.inverse" thing is only used if you need to define some tricky inverse operation, but will probably not be necessary in practice
-        // a custom value of opt.inverse needs to be an object of the form:
-        // {command:"$set",data:{fieldName:value}}
         // var fieldName = _.keys(actionField[0][1])[0]; // console.log(fieldName);
         if (typeof opt === 'undefined') {
           opt = {};    
         }
-        var inverseCommand = this._inverseOps[command];
-        var formerValues = {};
-        switch (inverseCommand) { // In case we need to do something special to make the inverse happen
-          default :
-            // TODO
-          case '$inc' :
-          case '$unset' :
-          case '$set' :
-            _.each(_.keys(updateMap), function(keyName) {
-              var formerVal = self._drillDown(existingDoc,keyName);
-              if (typeof formerVal !== 'undefined') {
-                formerValues[keyName] = formerVal;
-              }
-              else {
-                inverseCommand = '$unset';
-                formerValues[keyName] = '';
-              }
-            });
-            break;
-          case '$pull' :
-            formerValues = updateMap;
-            break;
-          /*case '$push' :
-            formerValues = updateMap;
-            break;*/
-          case '$addToSet' :
-            formerValues = updateMap;
-            break;
-          case '$pullAll' :
-            // TODO
-            break;
-          case '$pushAll' :
-            // TODO
-            break;
-        }
-        var inverse = {command:inverseCommand,data:formerValues}; // console.log("inverse op: ",JSON.stringify(inverse));
+        inverse = this.inverseOperations[command].call(self, collection, existingDoc, updateMap, opt);
       }
       else {
-        var inverse = opt.inverse;    
+        // This "opt.inverse" thing is only used if you need to define some tricky inverse operation, but will probably not be necessary in practice
+        // a custom value of opt.inverse needs to be an object of the form:
+        // {command:"$set",data:{fieldName:value}}
+        inverse = opt.inverse;    
       }
       self._setContext((opt && opt.context) || self.makeContext('update',collection,existingDoc,updates));
       var updateData = {command:command, data:updateMap};
@@ -568,13 +561,13 @@ Transact.prototype.update = function(collection,doc,updates,opt,callback) {
         }
       }
       else {
-		(function(updateData,inverse) {
-		  this._executionStack.push(function() {
-			doUpdate(collection,_id,updates,updateData,inverse,false,opt,callback);
-			self.log("Executed update");
-		  });
-		  this.log("Pushed update command to stack: " + this._transaction_id); //  + ' (Auto: ' + this._autoTransaction + ')'
-		}).call(this,updateData,inverse);
+    		(function(updateData,inverse) {
+    		  this._executionStack.push(function() {
+    			doUpdate(collection,_id,updates,updateData,inverse,false,opt,callback);
+    			self.log("Executed update");
+    		  });
+    		  this.log("Pushed update command to stack: " + this._transaction_id); //  + ' (Auto: ' + this._autoTransaction + ')'
+    		}).call(this,updateData,inverse);
       }
     }
     this._closeAutoTransaction(opt,callback);
@@ -925,6 +918,26 @@ Transact.prototype._drillDown = function(obj,key) {
   }*/
 }
 
+// Default inverse operation that uses $set to restore original state of updated fields
+
+Transact.prototype._inverseUsingSet = function (collection, existingDoc, updateMap, opt) {
+      var self = this, inverseCommand = '$set', formerValues = {};
+      _.each(_.keys(updateMap), function(keyName) {
+        var formerVal = self._drillDown(existingDoc,keyName);
+        if (typeof formerVal !== 'undefined') {
+          // Restore former value
+          inverseCommand = '$set';
+          formerValues[keyName] = formerVal;
+        }
+        else {
+          // Field was already unset, so just $unset it again
+          inverseCommand = '$unset';
+          formerValues[keyName] = '';
+        }
+      });
+      return {command:inverseCommand,data:formerValues};
+};
+
 // This (tx) is the object that gets exported for the app to interact with
 
 if (typeof tx === 'undefined') {
@@ -981,11 +994,11 @@ Meteor.methods({
         }
         if (_.isArray(lastTransaction.items.updated)) {
           if (!expired) {
-            _.each(lastTransaction.items.updated, function(obj) {// console.log("Undoing update: ", obj);
+            _.each(lastTransaction.items.updated, function(obj) { // console.log("Undoing update: ", JSON.stringify(obj));
               if (typeof obj.inverse !== 'undefined' && obj.inverse.command && obj.inverse.data) {
                 var operation = {};
-                operation[obj.inverse.command] = tx._unpackageForUpdate(obj.inverse.data);// console.log(operation);
-                queuedItems.push(function(){tx.collectionIndex[obj.collection].update({_id:obj._id},operation)});
+                operation[obj.inverse.command] = tx._unpackageForUpdate(obj.inverse.data); // console.log('inverse operation:'+JSON.stringify(operation));
+                queuedItems.push(function(){ tx.collectionIndex[obj.collection].update({_id:obj._id},operation); /* console.log("operation called:"+JSON.stringify(operation)); */ });
               }
             });
           }


### PR DESCRIPTION
Implement new tx.inverseOperations, allowing package users to easily globally override some or all of the default update inverse commands