### PR TITLE
make "context" a blackbox to SimpleSchema

### DIFF
--- a/lib/transactions_common.js
+++ b/lib/transactions_common.js
@@ -1143,6 +1143,7 @@ Meteor.startup(function() {
           "context": {
             type:Object,
             label:"Context",
+            blackbox:true,
             optional:true
           },
           "description": {


### PR DESCRIPTION
When using this package w/ SimpleSchema, custom context fields get "cleaned" and not saved