### PR TITLE
Add public function to manually add context to current transaction

### DIFF
--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -213,7 +213,7 @@ Transact.prototype.start = function (description, options) {
     this._description = description;
     
     // Set any transaction options e.g. context
-    if (typeof opts === 'object') {
+    if (typeof options === 'object') {
       if ('context' in options) this._context = options['context'];  
     }
     

--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -197,7 +197,7 @@ Transact = function () {
  *  Starts a transaction
  */
 
-Transact.prototype.start = function (description) {
+Transact.prototype.start = function (description, options) {
   if (tx.requireUser && !Meteor.userId()) {
     this.log('User must be logged in to start a transaction.');
     this._cleanReset();
@@ -205,10 +205,18 @@ Transact.prototype.start = function (description) {
   }
   this._resetAutoCancel();
   if (!this._transaction_id) {
+    
+    // Set transaction description 
     if (typeof description === 'undefined') {
       description = 'last action';  
     }
     this._description = description;
+    
+    // Set any transaction options e.g. context
+    if (typeof opts === 'object') {
+      if ('context' in options) this._context = options['context'];  
+    }
+    
     this._transaction_id = Random.id(); // Transactions.insert({user_id:Meteor.userId(),timestamp:(ServerTime.date()).getTime(),description:description});
     this.log('Started "' + description + '" with transaction_id: ' + this._transaction_id + ((this._autoTransaction) ? ' (auto started)' : ''));
     return this._transaction_id;

--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -961,6 +961,12 @@ Transact.prototype._setContext = function (context) {
   _.extend(this._context, context);  
 }
 
+// Public function to manually add context to current transaction
+
+Transact.prototype.setContext = function (context) {
+  this._setContext(context);
+}
+
 // This turns the data that has been stored in an array of key-value pairs into an object that mongo can use in an update
 
 Transact.prototype._unpackageForUpdate = function (data) {

--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -214,7 +214,7 @@ Transact.prototype.start = function (description, options) {
     
     // Set any transaction options e.g. context
     if (typeof options === 'object') {
-      if ('context' in options) this._context = options['context'];  
+      if ('context' in options) this._setContext(options['context']);
     }
     
     this._transaction_id = Random.id(); // Transactions.insert({user_id:Meteor.userId(),timestamp:(ServerTime.date()).getTime(),description:description});


### PR DESCRIPTION
I think it would be useful to be able to explicitly set transaction context. 

It makes sense for the context to apply to the whole transaction. A transaction is a "single action", and it's good to have context describing what that action is. But then it's counter-intuitive that you can only set context when you are adding an individual query. Why not set it explicitly on the level of the transaction itself?

The method you describe in the docs - selling an explicit context on the first query - is not neat in my case. I often add a list of queries to a transaction in a loop, so I would have to add context on the first iteration of the loop but not the others. 

Anything which could be described as "a use case" for a piece of software could reasonably be recorded in a context object. Thus, the possibilities are almost infinite. In many cases adding context as you add each query makes sense. But in my case, and perhaps other developers it seems neater to just set the transaction context explicitly in one go. 

I want to be able to do:

tx.start("TxnType")

... [ Do Queries ]

tx.setContext( context )

tx.commit()


Currently I'm doing:

tx._context = context 

tx.commit()


I realise this is a hack and might break in future versions. So I hope you will consider this pull request :)