### PR TITLE
Make Operations Synchronous 

### DIFF
--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -1231,7 +1231,7 @@ Transact.prototype._processTransaction = function (txid, description, items, con
   // STEP 2 - Make changes specified by items in the queue
   var success = true;
   var logErrors = function (err) {
-    console.log(err);
+    console.log(err.toString());
   };
   var updateCache = {};
   var cacheValues = function (item, index) {

--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -1274,16 +1274,14 @@ Transact.prototype._processTransaction = function (txid, description, items, con
         var txData = {transaction_id: txid};
         switch (item.action) {
           case 'insert' :
-            var newId = Collection.insert(_.extend(item.doc, {_id: item._id}, txData), function (err, res) {
-              if (err) {
-                success = false;
-                logErrors(err);
-              }
-              if (success) {
-                items[index].state = 'done';
-                tx.log("Executed insert");
-              }
-            });
+            // Will run synchronously. If this fails an exception will be thrown
+            var newId = Collection.insert(_.extend(item.doc, {_id: item._id}, txData));
+
+            // The insert succeeded
+            items[index].state = 'done';
+            tx.log("Executed insert");
+
+
             break;
           case 'update' :
             var modifier = {};
@@ -1297,47 +1295,39 @@ Transact.prototype._processTransaction = function (txid, description, items, con
               // Add a $set modifier
               modifier["$set"] = txData;
             }
-            Collection.update({_id: item._id}, modifier, function (err, res) {
-              if (err) {
-                success = false;
-                logErrors(err); 
-              }
-            });
-            if (success) {
-              // Cache values
-			  if (item.update.command === "$set") {
-                cacheValues(item, index);
-			  }
-              items[index].state = 'done';
-              tx.log("Executed update");
+
+            // Will run synchronously. If this fails an exception will be thrown
+            Collection.update({_id: item._id}, modifier);
+
+            // The update succeeded
+            // Cache values
+            if (item.update.command === "$set") {
+              cacheValues(item, index);
             }
+            items[index].state = 'done';
+            tx.log("Executed update");
+
             break;
           case 'remove' :
             if (item.hardDelete) {
+
               // Remove the whole document
-              var removed = Collection.remove({_id: item._id}, function (err, res) {
-                if (err) {
-                  success = false;
-                  logErrors(err);
-                }
-              });
-              if (removed && success) {
-                items[index].state = 'done';
-                tx.log('Executed remove');
-              }
+              // Will run synchronously. If this fails an exception will be thrown
+              var removed = Collection.remove({_id: item._id});
+
+              // The remove succeeded
+              items[index].state = 'done';
+              tx.log('Executed remove');
             }
             else {
               // Just do a soft delete
-              Collection.update({_id: item._id}, {$set: _.extend(txData, {deleted: ServerTime.date()})}, function (err, res) {
-                if (err) {
-                  success = false;
-                  logErrors(err);    
-                }
-              });
-              if (success) {
-                items[index].state = 'done';
-                tx.log('Executed remove');  
-              }
+              // Will run synchronously. If this fails an exception will be thrown
+              Collection.update({_id: item._id}, {$set: _.extend(txData, {deleted: ServerTime.date()})});
+
+              // The remove succeeded
+              items[index].state = 'done';
+              tx.log('Executed remove');
+
             }
             break;
           default :


### PR DESCRIPTION
Before this PR Collection Ops were executed Asynchronously. Now they are executed Synchronously. 

Async can mean operations are executed in a different order the user specification. 

For example, if you want to re-order a list you might $pull the item and then $push it somewhere else. If the $pull request is long running and the $push is quick - the $push may complete first. This means you very briefly have two copies of the item in the list, and you end up with none. This happened to me yesterday. 

In addition, with Async transaction errors might not be caught and rolled back properly.

The `if (success) {` below the operation might be executed before the callback has completed and an error has been recorded. 

From this code it looks like you might have intended these operations by to Synchronous. If so to be fair the Meteor docs are not at all clear - they refer to "callback" rather than "asyncCallback" like for HTTP. 

Apparently earlier versions of Meteor docs make this clear. See this SO post http://stackoverflow.com/a/16908957/3048733

Now they're Synchronous they will throw an error in case of failure. This will be caught by the pre-existing catch block. 