### PR TITLE
Collection.insert should not mutate the caller's newDoc object.

### DIFF
--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -543,6 +543,7 @@ Transact.prototype.insert = function (collection, newDoc, opt, callback) {
     opt = opt.tx;
   }
   opt = (_.isObject(opt)) ? _.omit(opt,'tx') : undefined; // This is in case we're going to pass this options object on to, say, collection2 (tx must be gone or we'll create an infinite loop)
+  newDoc = _.clone(newDoc);
   // NOTE: "collection" is the collection object itself, not a string
   if (this._permissionCheckOverridden(opt) || this._permissionCheck("insert", collection, newDoc, {})) {
     var self = this;
@@ -551,7 +552,7 @@ Transact.prototype.insert = function (collection, newDoc, opt, callback) {
     if ((typeof opt !== 'undefined' && opt.instant)) { // || this._autoTransaction
       try {
         var newId = newDoc._id || Random.id();
-        var newDoc = _.extend(newDoc, {_id: newId, transaction_id: self._transaction_id});
+        _.extend(newDoc, {_id: newId, transaction_id: self._transaction_id});
         var newId = self._doInsert(collection, newDoc, opt, callback); // Should give the same newId value as the one we passed
         var item = self._createItem('insert', collection, newId, {doc: newDoc}, true, self._permissionCheckOverridden(opt));
         this._recordTransaction(item);

--- a/testapp/tests/jasmine/server/integration/commitable-actions-spec.js
+++ b/testapp/tests/jasmine/server/integration/commitable-actions-spec.js
@@ -18,8 +18,9 @@ describe('committable actions', function () {
     // SETUP
     var predefinedId = 'PNAJ67oTkkaH46xJz';
     tx.start('insert transaction');
-    fooCollection.insert(
-      {_id: predefinedId, foo: "After insert"}, {tx: true});
+    var origDoc = {_id: predefinedId, foo: "After insert"};
+    var insertDoc = _.clone(origDoc);
+    fooCollection.insert(insertDoc, {tx: true});
 
     // EXECUTE
     tx.commit();
@@ -29,8 +30,8 @@ describe('committable actions', function () {
 
     expect(savedDoc).toBeDefined();
     expect(savedDoc.foo).toEqual('After insert');
-
-
+    // Collection.insert should not mutate its argument.
+    expect(insertDoc).toEqual(origDoc);
   });
 
 


### PR DESCRIPTION
The mutation broke our app [here](https://bitbucket.org/objsheets/objsheets/src/24385784ab87d0e4496eb5961e05db05476cb86a/src/server/model.ts?at=master&fileviewer=file-view-default#model.ts-602), where we created the `keyFields` object, inserted it as a document, and later used it as a selector, intending to find the same document.  Since the transaction package set `keyFields.transaction_id` and the transaction ID of the document in the database had been changed by the intervening update, the selector didn't match.  One could argue that our code is dodgy, but I think there's a stronger general principle that API calls should not mutate their arguments unless documented as doing so.

Note: I tested that in combination with #67 (ignoring the other four test failures), the new test fails on the old code and passes on the new code.