### PR TITLE
Fix bugs related to remove actions

### DIFF
--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -1426,8 +1426,10 @@ Transact.prototype._processTransaction = function (txid, description, items, con
   
   // First, need to iterate over the changes that are going to be made and make sure that,
   // if there are hard removes, the db version of the doc gets stored on the transaction
+  // We only do this step if the remove is not instant - otherwise the doc would already have
+  // been removed from the collection by this point.   
   _.each(items, function (item, index) {
-    if (item.action === "remove" && item.hardDelete) {
+    if (item.action === "remove" && item.hardDelete && !item.instant) {
       // Get the existing doc and store it in the transaction record
       // We overwrite the temporary version of the doc from an instant remove on the client
       // Because chances are that the whole document was not available on the client
@@ -1570,7 +1572,7 @@ Transact.prototype._processTransaction = function (txid, description, items, con
   // STEP 3 - Set state to "done"
   if (success) {
     var self = this;
-    Transactions.update({_id: txid}, {$set: {state: "done", lastModified: ServerTime.date()}}, function (err, res) {
+    Transactions.update({_id: txid}, {$set: {state: "done", items: items, lastModified: ServerTime.date()}}, function (err, res) {
       if (err) {
         self.log('Could not complete transaction:', txid, err);
         success = false;    


### PR DESCRIPTION
Prior to fix if there's a remove action that's { instant: false } in a txn with some { instant: true } actions, the removed doc would not be saved. If the remove action was in txn with other { instant: false } items only - it would work because on line 1444 there wouldn't be an existing txn yet, so the items - including the removed doc added on line 1438 - would be saved at that point. This is fixed now saving items on line 1475. 

Also - the block beginning on line 1432 is now executed only if the remove is  { instant: false }. Prior to fix this would be setting doc=undefined on line 1438.