### PR TITLE
Don't set the "deleted" field of a saved hard-deleted document.

### DIFF
--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -1051,7 +1051,6 @@ Transact.prototype._doRemove = function (collection, _id, sel, instant, opt, cal
     }
     else {
       fields.doc.transaction_id = self._transaction_id;
-      fields.doc.deleted = ServerTime.date();
     }
     var item = self._createItem("remove", collection, _id, fields, instant, self._permissionCheckOverridden(opt));
     self._recordTransaction(item);


### PR DESCRIPTION
This field caused the document to be restored as soft-deleted, which is
bogus even if the only concrete consequence for an app that doesn't look
at the "deleted" field is that a subsequent remove of the document will
fail with "Document not found for removal".  It's unclear to me what
purpose setting the field ever served.

Here's [a test case](https://github.com/mattmccutchen/meteor-transactions/tree/instant-hard-remove-test) to demonstrate the problem.  I wrote it using the test app since this was the easiest way, but I don't know if it's worth adding to our test suite.

Also, is there a purpose for setting the `transaction_id` of the saved document, or shall I remove that too while I'm here?  AFAICT, non-instant hard delete don't set it.