### PR TITLE
_processTransaction: Access per-transaction properties on "self", not "tx".

### DIFF
--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -1585,10 +1585,10 @@ Transact.prototype._processTransaction = function (txid, description, items, con
     self.log('Transaction failed');
     // Need to run the items through a rollback with actual inverse writes
     var rollbackAllDoneItems = true;
-    tx._transaction_id = txid;
-    tx._items = items;
-    tx._description = description;
-    tx._context = context;
+    self._transaction_id = txid;
+    self._items = items;
+    self._description = description;
+    self._context = context;
     tx.rollback.call(tx, rollbackAllDoneItems);
   }
         


### PR DESCRIPTION
This looks like an obvious mistake, but I haven't done a test to prove
that the current code is broken.