### PR TITLE
Add tx.allowAutoTransaction config prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ If you want a transaction that encompasses actions on several documents, you nee
 
 Note that each comment has to be removed independently. Transactions don't support `{multi: true}`.
 
+If you'd like to disable automatic starting of transactions then you can set the config prop `tx.allowAutoTransaction = false`. If you set this, an error will be thrown if you accidentally do a transaction action without calling `tx.start()` first. 
+
 #### Things it's helpful to know
 
 1. Although those look like mongo selectors in the `Posts.update` and `Posts.remove` examples above, they're really not. This package is only looking for an `_id` field in the object passed as the first parameter -- no other fields in the object are taken into account.

--- a/lib/transactions-common.js
+++ b/lib/transactions-common.js
@@ -171,6 +171,10 @@ TransactionManager = function () {
   
   this.forceCommitBeforeStart = false;
   
+  // By default, if we didn't call tx.start() before adding txn actions then a txn
+  // will be opened automatically. If this is disabled then an error will be thrown instead. 
+
+  this.allowAutoTransaction = true;
   
   // By default, the package swallows (but logs) errors during a commit
   // If you want it to rethrow the err, set this flag to false
@@ -1263,7 +1267,10 @@ Transact.prototype._callback = function (a, b, err, res, rethrowCommitError) {
 // Starts a transaction automatically if one isn't started already
 
 Transact.prototype._openAutoTransaction = function (description, opt) {// console.log("Auto open check value for transaction_id: " + this._transaction_id + ' (Auto: ' + this._autoTransaction + ')');
-  if (!this._transaction_id) {
+  if (!this._transaction_id) {  
+    if (!tx.allowAutoTransaction){
+      throw new Meteor.Error('Auto-Transactions are not allowed');
+    }
     this._autoTransaction = true;
     this._description = description;
     var options = {};


### PR DESCRIPTION
By default it's true - preserving the current behavior. If you set it as false, then an error will be thrown if you don't call tx.start() first. 

In our app we always use explicit txns, yet for some reason it sometimes starts committing actions as auto txns. Not sure about the underlying cause of the issue, which happens intermittently when the server is under high load. Either way - when things start going wrong we want to throw an error, not attempting to continue with an auto txn. 